### PR TITLE
Add --verbose flag to control syslog log level

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,12 +89,14 @@ fn real_main() -> Result<()> {
         poll_interval: u64,
         prometheus_push_gateway: Option<String>,
         print_bad_mounts: bool,
+        verbose: bool,
     }
     let mut options = Options {
         once_only: false,
         poll_interval: 60,
         prometheus_push_gateway: None,
         print_bad_mounts: false,
+        verbose: false,
     };
 
     {
@@ -138,6 +140,12 @@ fn real_main() -> Result<()> {
             "Print bad mounts on standard output",
         );
 
+        ap.refer(&mut options.verbose).add_option(
+            &["-v", "--verbose"],
+            StoreTrue,
+            "Enable debug-level logging, including per-mount health-check results",
+        );
+
         ap.parse_args_or_exit();
     }
 
@@ -150,7 +158,13 @@ fn real_main() -> Result<()> {
         );
     }
 
-    syslog::init_unix(syslog::Facility::LOG_USER, log::LevelFilter::Debug)
+    let log_level = if options.verbose {
+        log::LevelFilter::Debug
+    } else {
+        log::LevelFilter::Info
+    };
+
+    syslog::init_unix(syslog::Facility::LOG_USER, log_level)
         .chain_err(|| "Unable to connect to syslog")?;
 
     let mut mount_statuses = HashMap::<PathBuf, MountStatus>::new();


### PR DESCRIPTION
## Summary

The syslog logger was hardcoded to `LevelFilter::Debug`, so every poll cycle emitted per-mount "passed health-check" debug lines to syslog regardless of intent — noisy on hosts with many mounts.

This adds a `-v`/`--verbose` flag that controls the log level:

- **Default → `Info`**: per-cycle summary (`Checked N mounts; M are dead`) plus any `warn!`/`error!` output for slow or dead mounts.
- **`--verbose` → `Debug`**: additionally emits the per-mount `Mount passed health-check: …` detail.

## Changes

- `src/main.rs`: add `verbose: bool` to `Options`, wire up the `-v`/`--verbose` argparse option, and select `Debug` vs `Info` for `syslog::init_unix` based on it.

Source-only change (+16/−1); `Cargo.lock` untouched.

## Testing

- `cargo build --no-default-features` compiles cleanly (the default `with_prometheus` feature needs openssl/pkg-config not present in the build env; unrelated to this change).
- `--verbose` appears in `--help` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

